### PR TITLE
[✅ Test] 인증 페이지 handleFileInputChange 함수 리팩토링, 테스트 코드 추가

### DIFF
--- a/src/Page/UploadPost/UploadPost.tsx
+++ b/src/Page/UploadPost/UploadPost.tsx
@@ -15,9 +15,8 @@ import {
   initMind,
 } from '../../Component/Mission/GroupArticle';
 
-import { notifyImgSizeLimitErr } from '../../Component/Toast/ImgSizeLimitMsg';
+import { validateImage, showToast } from './validateImage';
 import { notifyNetErr } from '../../Component/Toast/NetworkErrorMsg';
-import { notifyExtensionsBlockErr } from '../../Component/Toast/ExtensionsBlockMsg';
 
 import { getUser } from '../../API/Users';
 import { postCreateBoard } from '../../API/Boards';
@@ -34,6 +33,9 @@ import {
 } from '../../constant/error';
 import { GroupHeader } from '../GroupPage/GroupPageBarrel';
 
+import { SIZE_10MB } from '../../constant/uploadPost';
+import { allowedExtensions } from '../../data/uploadPost';
+
 interface Image {
   name: string;
   file: null | File;
@@ -41,7 +43,6 @@ interface Image {
 
 const UploadPost = () => {
   const INITIAL_TEXT = '오늘 작심 성공!';
-  const FILE_SIZE_LIMIT_10MB = 10485760;
 
   const navigate = useNavigate();
   const { mindId } = useParams();
@@ -99,22 +100,17 @@ const UploadPost = () => {
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files?.length) return;
-
-    const fileName = e.target.files[0].name;
-    const allowedExtensions = ['.png', '.jpg', '.jpeg'];
-    const fileExtension = fileName.slice(fileName.lastIndexOf('.'));
-
-    if (!allowedExtensions.includes(fileExtension.toLocaleLowerCase())) {
-      return notifyExtensionsBlockErr();
-    }
-
-    if (e.target.files[0].size > FILE_SIZE_LIMIT_10MB) {
-      return notifyImgSizeLimitErr();
-    }
-
     const file = e.target.files[0];
-    setImage({ name: file.name, file });
-    setImageUrl(URL.createObjectURL(file));
+
+    // 유효성 검사 함수 호출
+    const { isValid, errorMessage } = validateImage(file, allowedExtensions, SIZE_10MB);
+
+    if (isValid) {
+      setImage({ name: file.name, file });
+      setImageUrl(URL.createObjectURL(file));
+    } else {
+      showToast(errorMessage);
+    }
   };
 
   const handleFileInputClick = (e: React.MouseEvent<HTMLInputElement>) => {

--- a/src/Page/UploadPost/validateImage.test.ts
+++ b/src/Page/UploadPost/validateImage.test.ts
@@ -1,0 +1,83 @@
+import { isExtensionValid, validateImage } from './validateImage';
+
+// 파일 객체를 모의(Mock)하기 위한 유틸리티 함수
+const createMockFile = (name: string, size: number, type: string): File => {
+  const file = new File([''], name, { type });
+  Object.defineProperty(file, 'size', {
+    value: size,
+  });
+  return file;
+};
+
+describe('isExtensionValid Function', () => {
+  it('유효한 확장자라면 true를 리턴함', () => {
+    const fileName = 'image.jpeg';
+    const allowedExtensions = ['.jpeg', '.png', '.gif'];
+    const result = isExtensionValid(fileName, allowedExtensions);
+    expect(result).toBe(true);
+  });
+
+  it('대소문자 구분 없이 유효한 확장자라면 true를 리턴함', () => {
+    const fileName = 'image.JPEG';
+    const allowedExtensions = ['.jpeg', '.png', '.gif'];
+    const result = isExtensionValid(fileName, allowedExtensions);
+    expect(result).toBe(true);
+  });
+
+  it('유효하지 않은 확장자라면 false를 리턴함', () => {
+    const fileName = 'document.pdf';
+    const allowedExtensions = ['.jpeg', '.png', '.gif'];
+    const result = isExtensionValid(fileName, allowedExtensions);
+    expect(result).toBe(false);
+  });
+
+  it('확장자가 없는 경우 false를 리턴함', () => {
+    const fileName = 'image';
+    const allowedExtensions = ['.jpeg', '.png', '.gif'];
+    const result = isExtensionValid(fileName, allowedExtensions);
+    expect(result).toBe(false);
+  });
+
+  it('파일 이름에 점이 여러 개 있는 경우 제일 마지막 .을 기준으로 확장자를 판단하고 유효하면 true를 반환함', () => {
+    const fileName = 'archive.01.png';
+    const allowedExtensions = ['.png', '.zip'];
+    const result = isExtensionValid(fileName, allowedExtensions);
+    expect(result).toBe(true);
+  });
+});
+
+describe('validateImage Function', () => {
+  const allowedExtensions = ['.jpg', '.jpeg', '.png'];
+  const fileSizeLimit = 10 * 1024 * 1024; // 10MB
+
+  it('유효한 확장자와 허용 가능한 파일 크기를 가진 파일에 대해 true를 반환해야 함', () => {
+    const mockFile = createMockFile('image.jpg', 5 * 1024 * 1024, 'image/jpeg'); // 5MB
+    const validation = validateImage(mockFile, allowedExtensions, fileSizeLimit);
+    expect(validation).toEqual({ isValid: true, errorMessage: null });
+  });
+
+  it('허용되지 않는 확장자를 가진 파일에 대해 false와 "INVALID_FILE_EXTENSIONS" 오류 메시지를 반환해야 함', () => {
+    const mockFile = createMockFile('document.pdf', 3 * 1024 * 1024, 'application/pdf'); // 3MB
+    const validation = validateImage(mockFile, allowedExtensions, fileSizeLimit);
+    expect(validation).toEqual({ isValid: false, errorMessage: 'INVALID_FILE_EXTENSIONS' });
+  });
+
+  it('허용된 확장자를 가지지만 파일 크기가 제한을 초과하는 경우, false와 "INVALID_FILE_SIZE" 오류 메시지를 반환해야 함', () => {
+    const mockFile = createMockFile('large-image.jpg', 12 * 1024 * 1024, 'image/jpeg'); // 12MB
+    const validation = validateImage(mockFile, allowedExtensions, fileSizeLimit);
+    expect(validation).toEqual({ isValid: false, errorMessage: 'INVALID_FILE_SIZE' });
+  });
+
+  // 경계 테스트
+  it('파일 크기가 정확히 제한값인 경우 (10MB), 유효한 파일로 처리해야 함', () => {
+    const mockFile = createMockFile('exact-size-image.jpg', 10 * 1024 * 1024, 'image/jpeg'); // 정확히 10MB
+    const validation = validateImage(mockFile, allowedExtensions, fileSizeLimit);
+    expect(validation).toEqual({ isValid: true, errorMessage: null });
+  });
+
+  it('파일 크기가 제한값을 약간 초과하는 경우 (10MB + 1byte), 유효하지 않은 파일로 처리해야 함', () => {
+    const mockFile = createMockFile('slightly-large-image.jpg', 10 * 1024 * 1024 + 1, 'image/jpeg'); // 10MB + 1byte
+    const validation = validateImage(mockFile, allowedExtensions, fileSizeLimit);
+    expect(validation).toEqual({ isValid: false, errorMessage: 'INVALID_FILE_SIZE' });
+  });
+});

--- a/src/Page/UploadPost/validateImage.ts
+++ b/src/Page/UploadPost/validateImage.ts
@@ -1,0 +1,39 @@
+import { notifyExtensionsBlockErr } from '../../Component/Toast/ExtensionsBlockMsg';
+import { notifyImgSizeLimitErr } from '../../Component/Toast/ImgSizeLimitMsg';
+
+// 계산: 유효한 확장자 검사 함수
+export function isExtensionValid(fileName: string, allowedExtensions: string[]) {
+  const fileExtension = fileName.slice(fileName.lastIndexOf('.')).toLowerCase();
+  return allowedExtensions.includes(fileExtension);
+}
+
+// 계산: 이미지 유효성 검사
+export function validateImage(file: File, allowedExtensions: string[], fileSizeLimit: number) {
+  if (!isExtensionValid(file.name, allowedExtensions)) {
+    return {
+      isValid: false,
+      errorMessage: 'INVALID_FILE_EXTENSIONS',
+    };
+  }
+
+  if (file.size > fileSizeLimit) {
+    return {
+      isValid: false,
+      errorMessage: 'INVALID_FILE_SIZE',
+    };
+  }
+
+  return { isValid: true, errorMessage: null };
+}
+
+// 액션: 토스트 띄우는 함수
+export function showToast(toastType: string | null) {
+  switch (toastType) {
+    case 'INVALID_FILE_EXTENSIONS':
+      return notifyExtensionsBlockErr();
+    case 'INVALID_FILE_SIZE':
+      return notifyImgSizeLimitErr();
+    default:
+      return;
+  }
+}

--- a/src/constant/uploadPost.ts
+++ b/src/constant/uploadPost.ts
@@ -1,0 +1,1 @@
+export const SIZE_10MB = 10485760;

--- a/src/data/uploadPost.ts
+++ b/src/data/uploadPost.ts
@@ -1,0 +1,1 @@
+export const allowedExtensions = ['.png', '.jpg', '.jpeg'];


### PR DESCRIPTION
## 변경사항 
- handleFileInputChange 함수에서 데이터, 계산 분리
- 분리한 계산 함수에 테스트 코드 추가 (이미지 유효성 검사)
  - 로컬 환경 테스트 속도 개선 (40s -> 2.6s)
    - 기존 수동 테스트: 약 40s 
    - 테스트 코드: 약 2.6s